### PR TITLE
chore(env): placed all key-value pairs to `.env.example` file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,5 @@
+BUCKET_SLUG=your_cosmic_bucket_slug
+READ_KEY=your_cosmic_read_key
+WRITE_KEY=your_cosmic_write_key
+NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=your_stripe_publishable_key
+STRIPE_SECRET_KEY=your_stripe_secret_key

--- a/README.md
+++ b/README.md
@@ -1,17 +1,21 @@
 # Next.js Non-Profit Website
+
 A non-profit website template powered by the [Cosmic headless CMS](https://www.cosmicjs.com). Uses Next.js, Tailwind CSS, and Stripe for donation payment processing.
 
 ## Links
+
 [Read how this website is built](https://www.cosmicjs.com/articles/build-a-non-profit-app-with-next-and-cosmic)<br/>
 [Install the App Template](https://www.cosmicjs.com/apps/nextjs-non-profit-website)<br/>
 [View the live demo](https://nextjs-non-profit-website.vercel.app/)
 
 ## Screenshots
+
 <img width="831" alt="non-profit-cms-6" src="https://user-images.githubusercontent.com/1950722/165220800-57880eff-c674-4a3e-b198-6e3900bb429e.png">
 
 <img width="1375" alt="nextjs-non-profit-website-2" src="https://user-images.githubusercontent.com/1950722/162981041-b316e4d1-2a59-4c9e-b49a-a52f653825aa.png">
 
 ## Getting Started
+
 First, install the dependencies with
 
 ```bash
@@ -26,17 +30,12 @@ yarn dev
 
 ## Environment Variables
 
-You'll need to create an `.env` file in the root of the project. It should have the following values:
+Refer to `.env.example` which is an example file for you to know what key-value pairs are needed for this project
 
-```env
-BUCKET_SLUG=your_cosmic_bucket_slug
-READ_KEY=your_cosmic_read_key
-WRITE_KEY=your_cosmic_write_key
-NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=your_stripe_publishable_key
-STRIPE_SECRET_KEY=your_stripe_secret_key
-```
+Then, create an `.env` file and copy the key-value pairs to it and then change the values
 
 ## Deploy
+
 <p>Use the following button to deploy to <a href="https://vercel.com/" rel="noopener noreferrer" target="_blank">Vercel</a>. You will need to add API accesss keys as environment variables. Find these in <em>Bucket Settings &gt; API Access</em><em>.</em></p>
 <p>
 <a href="https://vercel.com/import/git?c=1&s=https://vercel.com/import/git?c=1&s=https://github.com/cosmicjs/nextjs-non-profit-website&env=READ_KEY,WRITE_KEY,BUCKET_SLUG,STRIPE_SECRET_KEY,NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY" rel="noopener noreferrer" target="_blank"><img src="https://cdn.cosmicjs.com/d3f0d5e0-c064-11ea-9a05-6f8a16b0b14c-deploy-to-vercel.svg" style="width: 100px;" class="fr-fic fr-dib fr-fil"></a>


### PR DESCRIPTION
Hi, I noticed that all the key-value pairs needed are written down in `README.md`. As such, I think it's better to add a `.env.example` instead of writing it in `README.md`. Look forward to your reply and perhaps the merge of my PR to main branch. Thank you